### PR TITLE
feat: add drop support for badge and apply filter dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 	],
 	"activationEvents": [
 		"onCommand:fishbone.addNewFile",
-		"onCustomEditor:fishbone.fba"
+		"onCustomEditor:fishbone.fba",
+		"onView:fishbone_explorer.fba"
 	],
 	"capabilities": {
 		"virtualWorkspaces": true,
@@ -62,7 +63,16 @@
 					}
 				]
 			}
-		]
+		],
+		"views": {
+			"mbehr1Logs": [
+				{
+					"type": "tree",
+					"id": "fishbone_tree.fba",
+					"name": "Fishbone"
+				}
+			]
+		}
 	},
 	"scripts": {
 		"prepare": "husky install",

--- a/src/webview/src/components/fbaCheckbox.js
+++ b/src/webview/src/components/fbaCheckbox.js
@@ -227,7 +227,7 @@ export default function FBACheckbox(props) {
         ) {
             props.onChange({ target: { type: 'textfield', values: newValues } });
         } else {
-            console.warn(`FBACheckbox.handleClose no changes! newValues.filter=${JSON.stringify(newValues.filter)} vs ${JSON.stringify(props.filter)}`);
+            // console.warn(`FBACheckbox.handleClose no changes! newValues.filter=${JSON.stringify(newValues.filter)} vs ${JSON.stringify(props.filter)}`);
         }
     };
 

--- a/src/webview/src/util.js
+++ b/src/webview/src/util.js
@@ -213,3 +213,6 @@ export function numberAbbrev(data, max) {
     if (typeof data === 'number' && data > max) { return `${max}+`; }
     return data;
 }
+
+// array of [eventType:String, handler(event):bool]
+export const customEventStack = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2020",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es2020"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
Within the badges or 'apply filter' dialog filters from dlt-logs extension can now be dropped.
Sadly vscode doesn't allow drop into the webview directly thus in the Logs activity bar a section "Fishbone" has been added that contains a tree view with the opened fishbone files. Dropping a filter onto the file uses them if the
edit badge/apply flter dialog is opened.