### PR TITLE
feat: add JSON5 support for conv function

### DIFF
--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -13,6 +13,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "dompurify": "^2.4.0",
+    "json5": "2.2.3",
     "json-stable-stringify": "^1.0.1",
     "marked": "^3.0.8",
     "react": "^18.2.0",

--- a/src/webview/src/util.js
+++ b/src/webview/src/util.js
@@ -1,6 +1,15 @@
 // copyright (c) 2020 - 2023, Matthias Behr
 // util.js
-import jp from 'jsonpath' 
+import jp from 'jsonpath'
+
+// provide JSON5.parse for conversion functions:
+import JSON5 from 'json5'
+
+// eslint-disable-next-line no-undef
+if (!globalThis.JSON5) {
+    // eslint-disable-next-line no-undef
+    globalThis.JSON5 = JSON5;
+}
 
 // const vscode = window.acquireVsCodeApi();
 let vscode = undefined;

--- a/src/webview/yarn.lock
+++ b/src/webview/yarn.lock
@@ -6562,6 +6562,11 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
+json5@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"


### PR DESCRIPTION
conversion function can now use JSON5.parse(...) to e.g. support hex numbers, comments, etc.