### PR TITLE
feat: add dlt-logs-utils support

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
+    "dlt-logs-utils": "0.0.2",
     "tslib": "2.6.2",
     "@vscode/extension-telemetry": "^0.8.4",
     "jju": "github:mbehr1/jju#3aa4169df926e99083fdd511d7c20b5bd9ba789f",

--- a/src/extension/fbaNBRQRenderer.ts
+++ b/src/extension/fbaNBRQRenderer.ts
@@ -15,6 +15,7 @@ const jju = require('jju')
 import { RawNotebookCell } from './fbaNotebookProvider'
 import { DocData, FBAEditorProvider, FBBadge } from './fbaEditor'
 import { arrayEquals, getMemberParent, MemberPath } from './util'
+import * as uv0 from 'dlt-logs-utils'
 import { NotebookCellOutput } from 'vscode'
 
 interface RQCmd {
@@ -439,6 +440,9 @@ export class FBANBRestQueryRenderer {
             if (!(globalThis as any).JSON5) {
               ;(globalThis as any).JSON5 = JSON5
             }
+            if (!('uv0' in globalThis)) {
+              ;(globalThis as any).uv0 = uv0
+            }
             const fn = Function('matches,params', fnText)
             // do a restQuery for the filter surrounded.
             const queryCell = FBANBRestQueryRenderer.getCellByMembers(notebook, fbUidMembers.slice(0, fbUidMembers.length - 3))
@@ -454,7 +458,7 @@ export class FBANBRestQueryRenderer {
                     appendMarkdown(exec, [
                       { summary: 'querying filter:', texts: [...codeBlock(JSON.stringify(filterWoReportOptions, undefined, 2), 'json')] },
                     ])
-                    // todo: this contains a lot on code with internals from dlt-logs. Should move to a lib or completely as a
+                    // todo: this contains a lot of code with internals from dlt-logs. Should move to a lib or completely as a
                     // new restQuery to dlt-logs.
                     const filterRq: RQ = {
                       path: 'ext:mbehr1.dlt-logs/get/docs/0/filters?', // todo get from cell data!

--- a/src/extension/fbaNotebookProvider.ts
+++ b/src/extension/fbaNotebookProvider.ts
@@ -24,7 +24,7 @@ export class FBANotebookProvider implements Disposable {
 
     this.nbController = vscode.notebooks.createNotebookController('fba-nb-controller-1', 'fba-nb', 'Fishbone Notebook')
     this.subscriptions.push(this.nbController)
-    this.nbController.supportedLanguages = ['javascript', 'json', 'fbJsonPath']
+    this.nbController.supportedLanguages = ['javascript', 'json', 'jsonc', 'fbJsonPath']
     this.nbController.supportsExecutionOrder = true // or false?
     this.nbController.description = 'Fishbone Notebook to edit/test root causes, filters, conversionFns,...'
     this.nbController.executeHandler = this._executeAll.bind(this)

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -13,6 +13,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "dlt-logs-utils": "0.0.2",
     "dompurify": "^2.4.0",
     "jju": "github:mbehr1/jju#3aa4169df926e99083fdd511d7c20b5bd9ba789f",
     "js-yaml": "^4.1.0",

--- a/src/webview/src/util.js
+++ b/src/webview/src/util.js
@@ -4,11 +4,18 @@ import jp from 'jsonpath'
 
 // provide JSON5.parse for conversion functions:
 import JSON5 from 'json5'
+import * as uv0 from 'dlt-logs-utils'
 
 // eslint-disable-next-line no-undef
 if (!globalThis.JSON5) {
   // eslint-disable-next-line no-undef
   globalThis.JSON5 = JSON5
+}
+
+// eslint-disable-next-line no-undef
+if (!globalThis.uv0) {
+  // eslint-disable-next-line no-undef
+  globalThis.uv0 = uv0
 }
 
 class StandaloneApi {

--- a/src/webview/yarn.lock
+++ b/src/webview/yarn.lock
@@ -4259,6 +4259,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dlt-logs-utils@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/dlt-logs-utils/-/dlt-logs-utils-0.0.2.tgz#b5d8a205c8eee876101fa00e76e6526bd809de8e"
+  integrity sha512-ApjoO5ng57axu6KEa7tHU8nv1dgpa4yYMmFRCshCW85+44Wzv+1iEIuoV0LiID+9Hay9wt0czwdDBOa1qn74ug==
+
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2020",
+		"target": "es2021",
 		"outDir": "out",
 		"lib": [
-			"es2020"
+			"es2021"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,6 +2285,11 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dlt-logs-utils@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/dlt-logs-utils/-/dlt-logs-utils-0.0.2.tgz#b5d8a205c8eee876101fa00e76e6526bd809de8e"
+  integrity sha512-ApjoO5ng57axu6KEa7tHU8nv1dgpa4yYMmFRCshCW85+44Wzv+1iEIuoV0LiID+9Hay9wt0czwdDBOa1qn74ug==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"


### PR DESCRIPTION
Import 'uv0' as dlt-logs-utils to be available for conversion functions. Usage: e.g. return new uv0.TL('group','lane', matches[1], {color:'red'})