### PR TITLE
fix(notebook): dont ignore member cell changes

### DIFF
--- a/src/extension/fbaNotebookProvider.ts
+++ b/src/extension/fbaNotebookProvider.ts
@@ -57,6 +57,21 @@ export class FBANotebookProvider implements Disposable {
       }),
     )
 
+    /*
+    this.subscriptions.push(
+      vscode.workspace.onDidChangeNotebookDocument((event) => {
+        try {
+          const idx = this.selectedNotebooks.findIndex((nb) => nb === event.notebook)
+          if (idx >= 0) {
+            // console.log(`FBANotebookProvider.onDidChangeNotebookDocument idx=${idx}}`)
+            FBANBRestQueryRenderer.onDidChangeNotebookDocument(event)
+          }
+        } catch (e) {
+          console.warn(`FBANotebookProvider.onDidChangeNotebookDocument got e=${e}`)
+        }
+      }),
+    )*/
+
     this.subscriptions.push(
       vscode.languages.registerHoverProvider(
         {


### PR DESCRIPTION
If e.g. the jsonc cell with restQuery and the conversionFunction (aka member) cell content both change prev. the member cell changed have been ignored. Now a check is done first whether the parent cell did change the value of that member. If so the parent cell value has preference and the member cell gets ignored. Otherwise both changes are used.