### PR TITLE
feat: update to dlt-logs-utils v0.2.0 with tlAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.8.4",
-    "dlt-logs-utils": "^0.1.0",
+    "dlt-logs-utils": "^0.2.0",
     "jju": "github:mbehr1/jju#3aa4169df926e99083fdd511d7c20b5bd9ba789f",
     "js-yaml": "^4.1.0",
     "json5": "2.2.3",

--- a/src/extension/fbaNBRQRenderer.ts
+++ b/src/extension/fbaNBRQRenderer.ts
@@ -112,7 +112,7 @@ export class FBANBRestQueryRenderer {
               const memberCells = FBANBRestQueryRenderer.createMemberCell(
                 rO,
                 'conversionFunction',
-                `### conversionFunction` + '\n\n```function(matches, param){```',
+                `### conversionFunction` + '\n\n```function(matches, params){```',
                 {
                   fbUid,
                   fbUidMembers: fbUidMembers.concat([cmdIdx.toString() + ':' + rqCmd.cmd, idx, 'reportOptions']),
@@ -823,7 +823,7 @@ export class FBANBRestQueryRenderer {
                   ...FBANBRestQueryRenderer.createMemberCell(
                     member,
                     memberRef,
-                    `### ${memberRef}` + '\n\n```function(matches, param){```', // todo this needs to match exactly the initial creation text!
+                    `### ${memberRef}` + '\n\n```function(matches, params){```', // todo this needs to match exactly the initial creation text!
                     { ...cell.metadata, fbUidMembers: cell.metadata.fbUidMembers.concat(token.stack) },
                   ),
                 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,10 +2285,10 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dlt-logs-utils@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dlt-logs-utils/-/dlt-logs-utils-0.1.0.tgz#440cad79bf2d045d27e5c1b6210db7ff3bbba85a"
-  integrity sha512-XlAolmR4UfDGimvlhzwW0N2xF7g70MibyforFLC76c5sTbgYd49IUSQY67C1wJSEcX3KqxQ5rcSCX7wk8B2Mjg==
+dlt-logs-utils@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dlt-logs-utils/-/dlt-logs-utils-0.2.0.tgz#13dc3c7c8305d0a77d7b937c6bc028f0fe1234bb"
+  integrity sha512-aByT16KJKlylHlQVBrN71gAQ+eRm9FSWAXCWkWwZcBxgrdusdlBVH6YwbNPlM2Rwndx09TGp5yaqtLCnukUDMw==
 
 doctrine@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
fixed typo param->params as well.