### PR TITLE
ci: override config-conventional version

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     "vsce": "^2.15.0",
     "vscode-test": "^1.6.1"
   },
+  "resolutions": {
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+  },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
     "dlt-logs-utils": "0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,10 +2073,10 @@ conventional-changelog-angular@^8.0.0:
   dependencies:
     compare-func "^2.0.0"
 
-conventional-changelog-conventionalcommits@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
-  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
+"conventional-changelog-conventionalcommits@>= 8.0.0", conventional-changelog-conventionalcommits@^7.0.2:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
+  integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==
   dependencies:
     compare-func "^2.0.0"
 


### PR DESCRIPTION
To avoid
https://github.com/semantic-release/release-notes-generator/issues/657