### PR TITLE
feat(ai): first version with fishbone.ai / copilot chat support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://mbehr1.github.io/fishbone/",
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.99.1"
   },
   "categories": [
     "Visualization",
@@ -46,6 +46,106 @@
   },
   "main": "./out/extension/extension.js",
   "contributes": {
+    "chatParticipants": [
+      {
+        "id": "fishbone.ai",
+        "name": "fai",
+        "fullName": "Fishbone Analyst",
+        "description": "Which analysis shall I help you with?",
+        "isSticky": true,
+        "commands": [
+          {
+            "name": "teach",
+            "description": "Provide help on how to use a fishbone"
+          },
+          {
+            "name": "analyse",
+            "description": "Perform fishbone analysis on a trace file"
+          },
+          {
+            "name": "list",
+            "description": "List all registered tools"
+          }
+        ],
+        "disambiguation": [
+          {
+            "category": "analysis",
+            "description": "The user wants to analyse logs or traces",
+            "examples": [
+              "Explain to me the scenarios in the trace",
+              "Perform a fishbone analysis on the dlt log"
+            ]
+          }
+        ]
+      }
+    ],
+    "languageModelTools": [
+      {
+        "name": "fishbone_rootcauseDetails",
+        "tags": [
+          "fishbone"
+        ],
+        "toolReferenceName": "rootcauseDetails",
+        "displayName": "Fishbone Root Cause Details",
+        "modelDescription": "Details of a root cause in a fishbone.",
+        "userDescription": "Provide details for a root cause in a fishbone",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(files)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "fbUid": {
+              "type": "string",
+              "description": "The uid of the root cause to provide details for. It needs to be exactly the fbUid without any additional characters pre- or appended."
+            }
+          }
+        }
+      },
+      {
+        "name": "fishbone_queryLogs",
+        "tags": [
+          "fishbone"
+        ],
+        "toolReferenceName": "queryLogs",
+        "displayName": "Query logs with filters",
+        "modelDescription": "Query matching dlt-logs with a set of filters. Returns all logs matching the provided filters.",
+        "userDescription": "Provide logs matching a set of filters",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(list-filter)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "number",
+                    "description": "The type of the filter (0 = pos, 1 = negative)."
+                  },
+                  "apid": {
+                    "type": "string",
+                    "description": "Optional apid (application id) to filter for."
+                  },
+                  "ctid": {
+                    "type": "string",
+                    "description": "Optional ctid (context id) to filter for."
+                  },
+                  "payloadRegex": {
+                    "type": "string",
+                    "description": "Optional regular expression to filter the payload of the log for."
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            }
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "fishbone.addNewFile",
@@ -79,7 +179,8 @@
         {
           "type": "tree",
           "id": "fishbone_tree.fba",
-          "name": "Fishbone"
+          "name": "Fishbone",
+          "icon": "fishbone-icon2.png"
         }
       ]
     },
@@ -126,7 +227,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.17.11",
     "@types/request": "^2.48.8",
-    "@types/vscode": "^1.80.0",
+    "@types/vscode": "^1.99.1",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "esbuild": "^0.24.0",
@@ -147,6 +248,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
+    "@vscode/prompt-tsx": "^0.3.0-alpha.24",
     "dlt-logs-utils": "0.13.3",
     "jju": "github:mbehr1/jju#3aa4169df926e99083fdd511d7c20b5bd9ba789f",
     "js-yaml": "^4.1.0",
@@ -156,6 +258,7 @@
     "mdast-util-gfm-table": "^2.0.0",
     "mdast-util-to-markdown": "^2.1.2",
     "request": "^2.88.2",
+    "safe-stable-stringify": "^2.5.0",
     "short-unique-id": "4.4.4",
     "tslib": "2.6.2"
   },

--- a/src/extension/fbAIProvider.ts
+++ b/src/extension/fbAIProvider.ts
@@ -1,0 +1,499 @@
+/**
+ * copyright (c) 2025, Matthias Behr
+ *
+ * todo:
+ * [x] - support Sequences
+ * [x] - support nested root causes
+ * [x] - provide generic log infos like timeframe covered in logs, lifecycles detected, nr of ecus...
+ * [x] - (done via tool QueryLogs) access to logs (e.g. via details for badges or from "apply filter" ones...)
+ * [ ] - add info to current attributes fo FishboneContext
+ * [ ] - provide resume times for lifecycles (needs to be added to dlt-logs rest query 'ecus' first)
+ * [ ] - add "overview" alike categories?
+ * [ ] - understand iterations, test-cases based on log markers
+ * [ ] - new links to rootcause? (to have just 1 root cause being part of multiple effects)
+ * [ ] - allow to set attributes (e.g. restrict ecus, restrict lifecycles)
+ * [ ] - new attribute to restrict timerange?
+ * [ ] - support a user/workspace specific knowledge base? (e.g. ecu a = ECU1+ECU2 in logs)
+ * [ ] - split ToolResults by priority (e.g. ok sequences -> summary only if at token limit)
+ * [ ] - add tool to appy filter frags
+ * [ ] - add tool to export a log based on e.g. lc, time range, ecu, filter,...
+ * [ ] - support change of active restquerydoc...
+ * [ ] - add help related features (help on creating a report, on filtering, ...)
+ * [ ] - add support for report filters (image capturing... uploading...)?
+ */
+
+import * as vscode from 'vscode'
+import * as jp from 'jsonpath/jsonpath.min.js'
+import * as JSON5 from 'json5'
+import TelemetryReporter from '@vscode/extension-telemetry'
+import { renderPrompt } from '@vscode/prompt-tsx'
+import { FBAIPrompt, ToolCallRound, ToolResultMetadata } from './fbAiHistory'
+import { DocData, FBAEditorProvider } from './fbaEditor'
+import { QueryLogsTool, RootcauseDetailsTool } from './fbAiTools'
+import { FBBadge, FBEffect, FBRootCause, Fishbone } from './fbaFormat'
+import { RQ, RQCmd, rqUriDecode } from 'dlt-logs-utils/restQuery'
+import { DltFilter, FbSequenceResult, SeqChecker } from 'dlt-logs-utils/sequence'
+import { FBANBRestQueryRenderer } from './fbaNBRQRenderer'
+import { IFBsToInclude } from './fbAiFishboneContext'
+
+interface IFaiChatResult extends vscode.ChatResult {
+  metadata: TsxToolUserMetadata
+}
+
+export interface TsxToolUserMetadata {
+  command?: string
+  toolCallsMetadata: ToolCallsMetadata
+}
+
+export interface ToolCallsMetadata {
+  toolCallRounds: ToolCallRound[]
+  toolCallResults: Record<string, vscode.LanguageModelToolResult>
+}
+
+export function isTsxToolUserMetadata(obj: unknown): obj is TsxToolUserMetadata {
+  // If you change the metadata format, you would have to make this stricter or handle old objects in old ChatRequest metadata
+  return (
+    !!obj &&
+    !!(obj as TsxToolUserMetadata).toolCallsMetadata &&
+    Array.isArray((obj as TsxToolUserMetadata).toolCallsMetadata.toolCallRounds)
+  )
+}
+
+export class FBAIProvider implements vscode.Disposable {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private editorProvider: FBAEditorProvider,
+    private readonly reporter?: TelemetryReporter,
+  ) {
+    console.log('FBAIProvider()...')
+
+    const fai = vscode.chat.createChatParticipant('fishbone.ai', this.handleChatRequest.bind(this))
+    fai.iconPath = vscode.Uri.joinPath(context.extensionUri, 'fishbone-icon.png')
+    fai.followupProvider = {
+      provideFollowups(
+        result: IFaiChatResult,
+        context: vscode.ChatContext,
+        token: vscode.CancellationToken,
+      ): vscode.ProviderResult<vscode.ChatFollowup[]> {
+        return this.provideFollowups(result, context, token)
+      },
+    }
+    context.subscriptions.push(fai)
+    context.subscriptions.push(vscode.lm.registerTool('fishbone_rootcauseDetails', new RootcauseDetailsTool(this)))
+    context.subscriptions.push(vscode.lm.registerTool('fishbone_queryLogs', new QueryLogsTool(this)))
+  }
+  dispose() {
+    console.log('FBAIProvider disposed')
+  }
+
+  async handleChatRequest(
+    request: vscode.ChatRequest,
+    context: vscode.ChatContext,
+    stream: vscode.ChatResponseStream,
+    token: vscode.CancellationToken,
+  ): Promise<IFaiChatResult> {
+    console.log(
+      `FBAIProvider.handleChatRequest(req.command='${request.command}' req.prompt='${request.prompt}' req.model.id='${
+        request.model.id
+      }') req.model=${JSON.stringify(request.model)}...`,
+    )
+    // todo how to check whether the model supports tools?
+
+    if (request.command === 'list') {
+      stream.markdown(`Available tools: ${vscode.lm.tools.map((tool) => tool.name).join(', ')}\n\n`)
+      return {
+        metadata: { command: request.command, toolCallsMetadata: { toolCallRounds: [], toolCallResults: {} } },
+      }
+    } else if (request.command === undefined || request.command === 'analyse') {
+      // TODO: how to detect a follow up chat vs. a new chat (e.g. with new logs/fbs)?
+
+      const tools = vscode.lm.tools.filter((tool) => tool.tags.includes('fishbone'))
+      const fbs: IFBsToInclude[] = this.editorProvider._treeRootNodes
+        .map((node) => {
+          return node.docData?.lastPostedObj !== undefined ? ({ fb: node.docData.lastPostedObj } as IFBsToInclude) : undefined
+        })
+        .filter((node) => node !== undefined)
+
+      stream.progress(`Analysing using ${fbs.length} fishbones using ${tools.length} tools...`)
+      try {
+        const prompt = await renderPrompt(
+          FBAIPrompt, // ctor
+          {
+            userQuery: request.prompt,
+            history: context.history,
+            provider: this,
+            activeDocUri: this.editorProvider._lastActiveRestQueryDoc.uri,
+            fbs,
+            toolCallRounds: [],
+            toolCallResults: {},
+            toolInvocationToken: request.toolInvocationToken,
+          }, // props
+          { modelMaxPromptTokens: request.model.maxInputTokens }, // endpoint
+          request.model, // tokenizerMetadata
+          /*undefined, // progress
+          token, // cancellationToken
+          OutputMode.VSCode // outputMode*/
+        )
+        let messages = prompt.messages
+
+        console.log(
+          `FBAIProvider.handleChatRequest(req.command='${request.command}' req.prompt='${request.prompt}' req.model.id='${request.model.id}') rendered prompt: #messages=${messages.length} with ${prompt.tokenCount} tokens`,
+        )
+
+        prompt.references.forEach((ref) => {
+          if (ref.anchor instanceof vscode.Uri || ref.anchor instanceof vscode.Location) {
+            stream.reference(ref.anchor)
+          }
+        })
+        // log the messages:
+        /*for (const m of messages) {
+          console.log(`FBAIProvider.handleChatRequest() message: ${JSON.stringify(m)}`)
+        }*/
+
+        const toolReferences = [...request.toolReferences]
+        const accumulatedToolResults: Record<string, vscode.LanguageModelToolResult> = {}
+        const toolCallRounds: ToolCallRound[] = []
+        const options: vscode.LanguageModelChatRequestOptions = {
+          justification: 'To make a request to @fishbone.ai tools',
+        }
+        const runWithTools = async (): Promise<void> => {
+          // If a toolReference is present, force the model to call that tool
+          const requestedTool = toolReferences.shift()
+          if (requestedTool) {
+            options.toolMode = vscode.LanguageModelChatToolMode.Required
+            options.tools = vscode.lm.tools.filter((tool) => tool.name === requestedTool.name)
+          } else {
+            options.toolMode = undefined
+            options.tools = [...tools]
+          }
+          let realNrTokens = 0
+          for (const m of messages) {
+            realNrTokens += await request.model.countTokens(m)
+          }
+          console.log(`FBAIProvider realNrTokens = ${realNrTokens}`)
+          const chatResponse = await request.model.sendRequest(messages, options, token)
+          console.log(
+            `FBAIProvider.handleChatRequest(req.command='${request.command}' req.prompt='${request.prompt}' req.model.id='${request.model.id}') request sent`,
+          )
+          let nrFragements = 0
+          const toolCalls: vscode.LanguageModelToolCallPart[] = []
+          let responseStr = ''
+          for await (const part of chatResponse.stream) {
+            if (part instanceof vscode.LanguageModelTextPart) {
+              stream.markdown(part.value)
+              responseStr += part.value
+            } else if (part instanceof vscode.LanguageModelToolCallPart) {
+              toolCalls.push(part)
+            }
+            nrFragements++
+          }
+          if (toolCalls.length) {
+            // If the model called any tools, then we do another round- render the prompt with those tool calls (rendering the PromptElements will invoke the tools)
+            // and include the tool results in the prompt for the next request.
+            toolCallRounds.push({
+              response: responseStr,
+              toolCalls,
+            })
+            const result = await renderPrompt(
+              FBAIPrompt, // ctor
+              {
+                userQuery: request.prompt,
+                history: context.history,
+                provider: this,
+                activeDocUri: this.editorProvider._lastActiveRestQueryDoc.uri,
+                fbs,
+                toolCallRounds,
+                toolCallResults: accumulatedToolResults,
+                toolInvocationToken: request.toolInvocationToken,
+              }, // props
+              { modelMaxPromptTokens: request.model.maxInputTokens }, // endpoint
+              request.model, // tokenizerMetadata
+            )
+            console.log(
+              `FBAIProvider.handleChatRequest() rendered prompt with tool calls: #messages=${result.messages.length} with ${result.tokenCount} tokens`,
+            )
+            messages = result.messages
+            /*for (const m of messages) {
+              console.log(`FBAI messages after tool renderPrompt:`,m)
+            }*/
+            const toolResultMetadata = result.metadata.getAll(ToolResultMetadata)
+            // console.log(`FBAI handleChatRequest got ${toolResultMetadata.length} toolResultMetadata`, toolResultMetadata)
+            if (toolResultMetadata?.length) {
+              // Cache tool results for later, so they can be incorporated into later prompts without calling the tool again
+              toolResultMetadata.forEach((meta) => (accumulatedToolResults[meta.toolCallId] = meta.result))
+            }
+            // This loops until the model doesn't want to call any more tools, then the request is done.
+            return runWithTools()
+          }
+        }
+
+        await runWithTools()
+
+        return {
+          metadata: {
+            command: request.command,
+            // Return tool call metadata so it can be used in prompt history on the next request
+            toolCallsMetadata: {
+              toolCallResults: accumulatedToolResults,
+              toolCallRounds,
+            },
+          } satisfies TsxToolUserMetadata,
+        }
+      } catch (err) {
+        console.error('Error in FBAIProvider.handleChatRequest:', err)
+        stream.progress(`oops. got an error: ${err}`)
+        //handleError(logger, err, stream);
+      }
+
+      // this.reporter?.logUsage('request', { kind: 'play' });
+      return { metadata: { command: request.command, toolCallsMetadata: { toolCallRounds: [], toolCallResults: {} } } }
+    }
+    return {
+      errorDetails: { message: 'not implemented yet', responseIsFiltered: false },
+      metadata: { command: request.command },
+    } as IFaiChatResult
+  }
+
+  provideFollowups(
+    result: IFaiChatResult,
+    context: vscode.ChatContext,
+    token: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.ChatFollowup[]> {
+    console.log(`FBAIProvider.provideFollowups(r.m.cmd=${result.metadata.command})...`)
+    return []
+  }
+
+  // # region support functions for fishbone access:
+  static iterateAllFBElements(fishbone: FBEffect[], parents: any[], fn: (type: string, elem: any, parent: any) => void) {
+    for (const effect of fishbone) {
+      fn('effect', effect, fishbone)
+      if (effect?.categories?.length) {
+        for (const category of effect.categories) {
+          fn('category', category, effect)
+          if (category?.rootCauses?.length) {
+            for (const rc of category.rootCauses) {
+              fn('rc', rc, category)
+              if (rc.type === 'nested') {
+                if (rc.data !== undefined) {
+                  FBAIProvider.iterateAllFBElements(rc.data, [...parents, rc], fn)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  public getRootCause(fb: Fishbone, fbUid: string): FBRootCause | undefined {
+    let found: FBRootCause | undefined = undefined
+    FBAIProvider.iterateAllFBElements(fb.fishbone, [], (type: string, elem: any, parent: any) => {
+      if (type === 'rc' && elem.fbUid === fbUid) {
+        found = elem
+      }
+    })
+    return found
+  }
+
+  public getFishbones(): DocData[] {
+    return this.editorProvider._treeRootNodes
+      .map((node) => (node.docData?.lastPostedObj ? node.docData : undefined))
+      .filter((node) => node !== undefined) as DocData[]
+  }
+
+  public performRestQueryUri(url: string) {
+    return this.editorProvider.performRestQueryUri(url)
+  }
+
+  public performRestQuery(docData: DocData, rq: RQ) {
+    return this.editorProvider.performRestQuery(docData, rq)
+  }
+
+  public substFilterAttributes(docData: DocData, filters: any[]) {
+    return this.editorProvider.substFilterAttributes(docData, filters)
+  }
+
+  public async evaluateRestQuery(docData: DocData, badge: FBBadge) {
+    if (badge.conv && badge.source && typeof badge.source === 'string' && badge.source.startsWith('ext:mbehr1.dlt-logs/')) {
+      try {
+        const rq = rqUriDecode(badge.source)
+        // for now always evaluate the first command that returns a value
+        for (const cmd of rq.commands) {
+          if (cmd.cmd === 'query') {
+            // todo what if multiple queries?
+            return this.performRestQuery(docData, rq).then(
+              (resJson) => {
+                //console.log(`FBAI evaluateRestQuery got resJson`)
+                let answer: { jsonPathResult?: any[]; convResult?: number | string; restQueryResult: any } = { restQueryResult: resJson }
+                let result = resJson
+                if (badge.jsonPath && badge.jsonPath.length > 0) {
+                  result = jp.query(resJson, badge.jsonPath)
+                  //console.log(`FBAI evaluateRestQuery queried jsonPath`)
+                  answer.jsonPathResult = result
+                }
+                if (badge.conv && badge.conv.length > 0) {
+                  const dataConv = badge.conv
+                  const indexFirstC = dataConv.indexOf(':')
+                  const convType = dataConv.slice(0, indexFirstC)
+                  const convParam = dataConv.slice(indexFirstC + 1)
+                  // console.log(`convType='${convType}' convParam='${convParam}' result=`, result);
+                  switch (convType) {
+                    case 'length':
+                      answer.convResult = Array.isArray(result) ? result.length : 0
+                      // console.log(`conv length from ${JSON.stringify(result)} returns '${JSON.stringify(answer.convResult)}'`);
+                      break
+                    case 'index':
+                      answer.convResult =
+                        Array.isArray(result) && result.length > Number(convParam)
+                          ? typeof result[Number(convParam)] === 'string'
+                            ? result[Number(convParam)]
+                            : JSON.stringify(result[Number(convParam)])
+                          : 0
+                      break
+                    case 'func':
+                      // todo try catch... conv to string/number
+                      try {
+                        // eslint-disable-next-line no-new-func
+                        const fn = new Function('result', convParam)
+                        const fnRes = fn(result)
+                        //console.log(`typeof fnRes='${typeof fnRes}'`);
+                        switch (typeof fnRes) {
+                          case 'string':
+                          case 'number':
+                            answer.convResult = fnRes
+                            break
+                          case 'object':
+                            answer.convResult = JSON.stringify(fnRes)
+                            break
+                          default:
+                            answer.convResult = `unknown result type '${typeof fnRes}'. Please return string or number`
+                            break
+                        }
+                      } catch (e) {
+                        answer.convResult = `got error e='${e}' from conv function`
+                      }
+                      break
+                    default:
+                      answer.convResult = `unknown convType ${convType}`
+                      break
+                  }
+                }
+                result =
+                  answer.convResult !== undefined
+                    ? answer.convResult
+                    : answer.jsonPathResult !== undefined
+                      ? answer.jsonPathResult
+                      : answer.restQueryResult
+                return result
+              },
+              (rejectReason) => {},
+            )
+          } else if (cmd.cmd === 'sequences') {
+            // for now we do implement it here (again) instead of using the dlt-logs sequence
+            // and adding e.g. seqDetails and some sequence.scopes... to enable details
+            // We do this to e.g. later support providing a summary only for a single occurrence
+            // to avoid largely nested tables/markdowns.
+            const r = await this.evaluateSequence(docData, rq, cmd)
+            if (r !== undefined) {
+              return r
+            } // else ignore
+          } else {
+            console.log(`rq.cmd=${cmd} ignored!`)
+          }
+        }
+      } catch (e) {
+        console.warn(`evaluateRestQuery got error:${e}`)
+      }
+    }
+  }
+
+  private async evaluateSequence(docData: DocData, rq: RQ, cmd: RQCmd) {
+    try {
+      const maxNrMsgs = 1_000_000
+      const sequences = JSON5.parse(cmd.param)
+      if (Array.isArray(sequences) && sequences.length > 0) {
+        // code similar to fbaNBRQRenderer.executeSequences... (todo refactor)
+        const resPromises = []
+        for (const jsonSeq of sequences) {
+          const seqResult: FbSequenceResult = {
+            sequence: jsonSeq,
+            occurrences: [],
+            logs: [],
+          }
+          const seqChecker = new SeqChecker(jsonSeq, seqResult, DltFilter)
+          const allFilters = seqChecker.getAllFilters()
+          if (allFilters.length === 0) {
+            continue
+          }
+          // we do want lifecycle infos as well
+          allFilters[0].addLifecycles = true
+          allFilters[0].maxNrMsgs = maxNrMsgs + 1 // one more to detect whether we ran into the limit
+          const allFiltersRq: RQ = {
+            path: rq.path,
+            commands: [
+              {
+                cmd: 'query',
+                param: JSON.stringify(allFilters),
+              },
+            ],
+          }
+          resPromises.push(
+            this.performRestQuery(docData, allFiltersRq).then(
+              (resJson) => {
+                if ('data' in resJson && Array.isArray(resJson.data)) {
+                  const lifecycles = new Map(
+                    (<any[]>resJson.data)
+                      .filter((d: any) => d.type === 'lifecycles')
+                      .map((d: any) => [d.id as number, FBANBRestQueryRenderer.getLCInfoFromRQLc(d.attributes)]),
+                  )
+                  const msgs = <any[]>resJson.data
+                    .filter((d: any) => d.type === 'msg')
+                    .map((d: any) => {
+                      const lifecycle = lifecycles.get(d.attributes.lifecycle)
+                      return {
+                        index: d.id,
+                        ...d.attributes,
+                        lifecycle,
+                        receptionTimeInMs: lifecycle ? lifecycle.lifecycleStart.valueOf() + d.attributes.timeStamp / 10000 : 0,
+                      }
+                    })
+                  // console.log(`FBAI evaluateSequence ${seqChecker.name} got ${msgs.length} msgs`, resJson)
+                  const hitMaxNrMsgsLimit = msgs.length > maxNrMsgs
+                  if (hitMaxNrMsgsLimit) {
+                    msgs.splice(maxNrMsgs)
+                    // TODO add error/warning?
+                  }
+                  seqChecker.processMsgs(msgs)
+                  return seqResult
+                }
+                return `sequence '${seqChecker.name}' returned no data`
+              },
+              (failureReason) => {
+                const str = `sequence '${seqChecker.name}' evaluation failed with: ${failureReason}`
+                console.warn('FBAI evaluateSequence: ' + str)
+                return str
+              },
+            ),
+          )
+        }
+        const r = await Promise.allSettled(resPromises)
+        const r2: (string | FbSequenceResult)[] = r.map((setRes) => (setRes.status === 'fulfilled' ? setRes.value : setRes.reason))
+        return new SequencesResult(r2)
+      } else {
+        console.warn(`rq.cmd=${cmd} ignored as no sequences provided!`)
+      }
+    } catch (e) {
+      console.warn(`evaluateSequence got error:${e}`)
+    }
+  }
+}
+
+/**
+ *  a class to be able to check for instance of...
+ *
+ * result is an array for each sequence within the sequences=[] rest query
+ * Every entry is either a string representing an error (during exec or no data)
+ * Or a FbSequenceResult object with all info from the SeqChecker.
+ * */
+export class SequencesResult {
+  constructor(public result: (string | FbSequenceResult)[]) {}
+}

--- a/src/extension/fbAiDltDocContext.tsx
+++ b/src/extension/fbAiDltDocContext.tsx
@@ -1,0 +1,76 @@
+import { BasePromptElementProps, PromptElement, PromptPiece, PromptSizing, UserMessage } from '@vscode/prompt-tsx'
+import { FBAIProvider } from './fbAIProvider'
+
+export class DltDocContext extends PromptElement<{ provider: FBAIProvider; activeDocUri: string | undefined } & BasePromptElementProps> {
+  async render(_state: void, sizing: PromptSizing): Promise<PromptPiece> {
+    console.log(`FBAI DltDocContext.render for doc:'${this.props.activeDocUri}`)
+
+    if (this.props.activeDocUri) {
+      const docInfo = await this.queryDocInfo()
+      console.log(`FBAI DltDocContext.render got docInfo:`, docInfo)
+
+      return (
+        <>
+          <UserMessage priority={this.props.priority}>`The active DLT document has the uri:'${this.props.activeDocUri}'.`</UserMessage>
+          {typeof docInfo === 'object' /* provide general stats like nr. of messages */ && (
+            <UserMessage priority={this.props.priority}>
+              `The document contains ${docInfo.length} ${docInfo.length > 1 ? 'ECUs' : 'ECU'} named: $
+              {docInfo.map((ecu) => ecu.attributes.name).join(', ')}.`
+            </UserMessage>
+          )}
+          {
+            /* provide contained ECUs with nr of messages */ typeof docInfo === 'object' && (
+              <UserMessage priority={this.props.priority}>
+                {docInfo
+                  .map((ecu) => {
+                    return (
+                      (ecu.attributes.sws.length > 0
+                        ? `The ECU '${ecu.attributes.name}' has SW versions: ${ecu.attributes.sws.join(', ')}.\n`
+                        : `The SW versions for ECU '${ecu.attributes.name}' are not identified.`) +
+                      `It has ${
+                        ecu.attributes.lifecycles.length
+                      } lifecycles identified:\n` +
+                      ecu.attributes.lifecycles.map((lc) => `#${lc.id}: ${lc.attributes.startTimeUtc} - ${lc.attributes.endTimeUtc} with ${lc.attributes.msgs} log messages`).join(',\n') + '.'
+                    )
+                  })
+                  .join('\n\n')}
+              </UserMessage>
+            )
+          }
+          {/* TODO provide apid/ctid info with lower priority */}
+        </>
+      )
+    } else {
+      return (
+        <UserMessage priority={this.props.priority}>
+          `There is no active DLT document. Open one in the editor. Currently only information about open fishbone documents are available.`
+        </UserMessage>
+      )
+    }
+  }
+
+  async queryDocInfo() {
+    // try a query to dlt-logs ext:
+    const uri = 'ext:mbehr1.dlt-logs' + '/get/docs/0/ecus'
+    return this.props.provider.performRestQueryUri(uri).then(
+      (resJson) => {
+        if ('data' in resJson && Array.isArray(resJson.data)) {
+          return resJson.data as {
+            type: 'ecus'
+            id: string
+            attributes: {
+              name: string
+              lifecycles: { type: 'lifecycles'; id: number; attributes: { startTimeUtc: string; endTimeUtc: string; msgs: number } }[]
+              sws: string[]
+            }
+          }[]
+        } else {
+          return `querying document info returned no data`
+        }
+      },
+      (rejectReason) => {
+        return `querying document info failed with reason: ${rejectReason}`
+      },
+    )
+  }
+}

--- a/src/extension/fbAiFishboneContext.tsx
+++ b/src/extension/fbAiFishboneContext.tsx
@@ -1,0 +1,100 @@
+import { BasePromptElementProps, PromptElement, PromptPiece, PromptSizing, UserMessage } from '@vscode/prompt-tsx'
+import { stringify } from 'safe-stable-stringify'
+import { Fishbone } from './fbaFormat'
+
+export interface IFBsToInclude {
+  fb: Fishbone
+  // line: number
+}
+
+export function hashForFishbone(fb: Fishbone): number {
+  return cyrb53(safeStableStringify(fb)) // TODO could remove backups here
+}
+
+export class FishboneContext extends PromptElement<{ fbs: IFBsToInclude[], fbaHash?: number } & BasePromptElementProps> {
+  renderFishbone(fb: IFBsToInclude): PromptPiece {
+    const fba = fb.fb
+    const fbaHash = hashForFishbone(fba)
+
+    return (
+      <>
+        <UserMessage priority={70}>Fishbone title: '{fba.title}''</UserMessage>
+        <UserMessage priority={70}>
+          This fishbone contains details for the following effects:
+          {fba.fishbone.map((e) => (
+            <UserMessage priority={70}>
+              <br />
+              {`effect: '${e.name}' with the following categories:`}
+              {e.categories.map((c) => (
+                <UserMessage priority={70}>
+                  <br />
+                  {`category:'${c.name}' with the following potential root causes:`}
+                  {c.rootCauses.map((r) => {
+                    if (r.type === 'nested' && r.data !== undefined) {
+                      const fb: Fishbone = {
+                        title: r.title || '<nested rc wo title>',
+                        attributes: fba.attributes,
+                        fishbone: r.data,
+                      }
+                      return <FishboneContext fbs={[{ fb }]} fbaHash={fbaHash} />
+                    } else {
+                      return (
+                        <UserMessage priority={70}>
+                          <br />
+                          {`root cause (fbUid:'${fbaHash}_${r.fbUid}'): '${r.title || r.props?.label || 'no title'}`}
+                        </UserMessage>
+                      )
+                    }
+                  })}
+                </UserMessage>
+              ))}
+            </UserMessage>
+          ))}
+        </UserMessage>
+      </>
+    )
+  }
+
+  async render(_state: void, sizing: PromptSizing): Promise<PromptPiece> {
+    // todo consider sizing.tokenBudget using sizing.countTokens(...)
+    return <>{this.props.fbs.map((f) => this.renderFishbone(f))}</>
+  }
+}
+
+// #region hash / safe-stable-stringify
+
+// TODO put into utils... (or even dlt-log-utils)
+/**
+ * Safely converts an object to a string representation, including support for BigInts.
+ *
+ * @param obj - The object to stringify.
+ * @returns The string representation of the object.
+ */
+function safeStableStringify(obj: any): string {
+  // safe-stable-stringify handles bigints but by representing as number strings that
+  // later on cannot be parsed and where the info that it was a bigint got lost
+  // so we convert bigints to strings with the number + 'n' here
+  return stringify(obj, (_, v) => (typeof v === 'bigint' ? v.toString() + 'n' : v)) || ''
+}
+
+// cyrb53 (c) 2018 bryc (github.com/bryc). License: Public domain. Attribution appreciated.
+// A fast and simple 64-bit (or 53-bit) string hash function with decent collision resistance.
+// Largely inspired by MurmurHash2/3, but with a focus on speed/simplicity.
+// See https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript/52171480#52171480
+// https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+const cyrb53 = (str:string, seed = 0) => {
+  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed
+  for(let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1  = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2  = Math.imul(h2 ^ (h2 >>> 16), 2246822507)
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  // For a single 53-bit numeric return value we could return
+  // 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  // but we instead return the full 64-bit value: (we dont. modified)
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0) // .toString(); // [h2>>>0, h1>>>0];
+}

--- a/src/extension/fbAiHistory.tsx
+++ b/src/extension/fbAiHistory.tsx
@@ -1,0 +1,313 @@
+/**
+ * copyright (c) 2025, Matthias Behr
+ * 
+ * template copied from https://github.com/microsoft/vscode-prompt-tsx/blob/main/examples/history.tsx, MIT license
+ */
+
+import {
+  AssistantMessage,
+  BasePromptElementProps,
+  Chunk,
+  PrioritizedList,
+  PromptElement,
+  PromptMetadata,
+  PromptPiece,
+  PromptSizing,
+  ToolCall,
+  ToolMessage,
+  ToolResult,
+  UserMessage,
+} from '@vscode/prompt-tsx'
+import {
+  CancellationToken,
+  CancellationTokenSource,
+  ChatContext,
+  ChatParticipantToolToken,
+  ChatRequestTurn,
+  ChatResponseMarkdownPart,
+  ChatResponseTurn,
+  LanguageModelToolCallPart,
+  LanguageModelToolResult,
+  LanguageModelToolTokenizationOptions,
+  lm,
+} from 'vscode'
+import { FBAIProvider, isTsxToolUserMetadata } from './fbAIProvider'
+import { DltDocContext } from './fbAiDltDocContext'
+import { IFBsToInclude, FishboneContext } from './fbAiFishboneContext'
+
+export interface ToolCallRound {
+  response: string
+  toolCalls: LanguageModelToolCallPart[]
+}
+
+interface IFBAIPromptProps extends BasePromptElementProps {
+  history: ChatContext['history'] // or full context
+  userQuery: string
+  provider: FBAIProvider
+  activeDocUri: string | undefined
+  fbs: IFBsToInclude[]
+  toolInvocationToken: ChatParticipantToolToken // or full request
+  toolCallRounds: ToolCallRound[]
+  toolCallResults: Record<string, LanguageModelToolResult>
+}
+
+/**
+ * Including conversation history in your prompt is important as it allows the
+ * user to ask followup questions to previous messages. However, you want to
+ * make sure its priority is treated appropriately because history can
+ * grow very large over time.
+ *
+ * We've found that the pattern which makes the most sense is usually to prioritize, in order:
+ *
+ * 1. The base prompt instructions, then
+ * 1. The current user query, then
+ * 1. The last couple turns of chat history, then
+ * 1. Any supporting data, then
+ * 1. As much of the remaining history as you can fit.
+ *
+ * For this reason, we split the history in two parts in the prompt, where
+ * recent prompt turns are prioritized above general contextual information.
+ */
+export class FBAIPrompt extends PromptElement<IFBAIPromptProps> {
+  render() {
+    const r = (
+      <>
+        <UserMessage priority={100}>
+          Your task is to analyse logs systematically via the help of fishbone files. The logs are typically in the form of dlt log files.
+          The fishbones to be used are part of opened fishbone fba files. You should start by trying to understand the problem description
+          first. Then you can use the fishbone files to help you understand the logs and systematically exclude possible causes or identify
+          possible root causes. Each fishbone can provide info on how to analyse multiple problems called 'effects'. Each effect can contain
+          various categories that cluster a set of possible root causes. Each fishbone root cause can contain additional information like
+          background and instructions and 'apply filter' filter details to query logs related to that root cause. Additionally a fishbone
+          root cause can contain an upper and a lower badge that are the results of filtering the logs and appyling some checks on the
+          returned messages. The upper badge usually indicates whether that potential root cause should be more carefully considered. The
+          lower badge usually extracts some data from the logs that can help in understanding root cause related aspects of the logs. The
+          filter details returned for 'apply filter' can be provided to the queryLogs tool as filters. Take care to provide exactly the
+          filters returned. To analyse a problem systematically do the following steps: 1. try to understand the problem description. It
+          should match any of the effects covered by the fishbone. If not ask the user which effect would match to the problem description.
+          2. evaluate all the potential root causes of the effect and its categories. Evaluate means that you should check the details for
+          the root cause i.e. consider the background info for each root cause and follow the instructions if the root cause might be
+          relevant. Use the info from the badges from each root cause as well. 3. List all potential root causes to the user that you think
+          are relevant for the problem description. If no root cause could be identified, give that info to the user and ask him to extend
+          the fishbone with the missing potential root causes. 4. Once you're done always provide the user with a short summary including: -
+          the identified problem description - the effects that matches the problem description - the root causes that you checked - the
+          root causes that you think are potentially relevant if any.
+        </UserMessage>
+        <DltDocContext priority={90} provider={this.props.provider} activeDocUri={this.props.activeDocUri} />
+        <FishboneContext priority={80} flexGrow={1} fbs={this.props.fbs}/>
+        <History history={this.props.history} passPriority older={0} newer={80} flexGrow={2} flexReserve='/5' />
+        {/* todo later ad references <PromptReferences
+					references={this.props.request.references}
+					priority={20}
+				/>*/}
+        {/* The user query is right behind the system message in priority */}
+        <UserMessage priority={90}>{this.props.userQuery}</UserMessage>
+        {/*<UserMessage priority={60}>
+          TODO: use it for e.g. lifecycle infos of the loaded dlt file.
+          Or the last used search terms.
+					With a slightly lower priority, you can include some contextual data about the workspace
+					or files here...
+				</UserMessage>*/}
+        <ToolCalls
+          fbs={this.props.fbs}
+          toolCallRounds={this.props.toolCallRounds}
+          toolInvocationToken={this.props.toolInvocationToken}
+          toolCallResults={this.props.toolCallResults}
+        />
+      </>
+    )
+    //console.warn(`FBAIPrompt.render()...r=${JSON.stringify(r)}`)
+    return r
+  }
+}
+
+interface IHistoryProps extends BasePromptElementProps {
+  history: ChatContext['history']
+  newer: number // last 2 message priority values
+  older: number // previous message priority values
+  passPriority: true // require this prop be set!
+}
+
+/**
+ * We can wrap up this history element to be a little easier to use. `prompt-tsx`
+ * has a `passPriority` attribute which allows an element to act as a 'pass-through'
+ * container, so that its children are pruned as if they were direct children of
+ * the parent. With this component, the elements
+ *
+ * ```
+ * <HistoryMessages history={this.props.history.slice(0, -2)} priority={0} />
+ * <HistoryMessages history={this.props.history.slice(-2)} priority={80} />
+ * ```
+ *
+ * ...can equivalently be expressed as:
+ *
+ * ```
+ * <History history={this.props.history} passPriority older={0} recentPriority={80} />
+ * ```
+ */
+export class History extends PromptElement<IHistoryProps> {
+  render(): PromptPiece {
+    return (
+      <>
+        <HistoryMessages history={this.props.history.slice(0, -2)} priority={this.props.older} />
+        <HistoryMessages history={this.props.history.slice(-2)} priority={this.props.newer} />
+      </>
+    )
+  }
+}
+
+interface IHistoryMessagesProps extends BasePromptElementProps {
+  history: ChatContext['history']
+}
+
+/**
+ * The History element simply lists user and assistant messages from the chat
+ * context. If things like tool calls or file trees are relevant for, your
+ * case, you can make this element more complex to handle those cases.
+ */
+export class HistoryMessages extends PromptElement<IHistoryMessagesProps> {
+  render(): PromptPiece {
+    const history: (UserMessage | AssistantMessage)[] = []
+    for (const turn of this.props.history) {
+      if (turn instanceof ChatRequestTurn) {
+        history.push(<UserMessage>{turn.prompt}</UserMessage>)
+      } else if (turn instanceof ChatResponseTurn) {
+        const metadata = turn.result.metadata
+        // console.log('FBAI HistoryMessage metadata:', metadata)
+        if (isTsxToolUserMetadata(metadata) && metadata.toolCallsMetadata.toolCallRounds.length > 0) {
+          // console.log('FBAI HistoryMessage ToolCalls found in history:', metadata.toolCallsMetadata)
+          history.push(
+            <ToolCalls
+              fbs={[]}
+              toolCallResults={metadata.toolCallsMetadata.toolCallResults}
+              toolCallRounds={metadata.toolCallsMetadata.toolCallRounds}
+              toolInvocationToken={undefined}
+            />,
+          )
+        } else {
+          history.push(<AssistantMessage name={turn.participant}>{chatResponseToMarkdown(turn)}</AssistantMessage>)
+        }
+      }
+    }
+    return (
+      <PrioritizedList priority={0} descending={false}>
+        {history}
+      </PrioritizedList>
+    )
+  }
+}
+
+const chatResponseToMarkdown = (response: ChatResponseTurn) => {
+  let str = ''
+  for (const part of response.response) {
+    if (response instanceof ChatResponseMarkdownPart) {
+      str += part.value
+    }
+  }
+
+  return str
+}
+
+// #region ToolCalls
+interface ToolCallsProps extends BasePromptElementProps {
+  fbs: IFBsToInclude[]
+  toolCallRounds: ToolCallRound[]
+  toolCallResults: Record<string, LanguageModelToolResult>
+  toolInvocationToken: ChatParticipantToolToken | undefined
+}
+
+const dummyCancellationToken: CancellationToken = new CancellationTokenSource().token
+
+/**
+ * Render a set of tool calls, which look like an AssistantMessage with a set of tool calls followed by the associated UserMessages containing results.
+ */
+class ToolCalls extends PromptElement<ToolCallsProps, void> {
+  async render(_state: void, _sizing: PromptSizing) {
+    if (!this.props.toolCallRounds.length) {
+      return undefined
+    }
+
+    // Note- for the copilot models, the final prompt must end with a non-tool-result UserMessage
+    return (
+      <>
+        {this.props.toolCallRounds.map((round) => this.renderOneToolCallRound(round))}
+        <UserMessage>
+          Above is the result of calling one or more tools. The user cannot see the results, so you should explain them to the user if
+          referencing them in your answer.
+        </UserMessage>
+      </>
+    )
+  }
+
+  private renderOneToolCallRound(round: ToolCallRound) {
+    const assistantToolCalls: ToolCall[] = round.toolCalls.map((tc) => ({
+      type: 'function',
+      function: { name: tc.name, arguments: JSON.stringify(tc.input) },
+      id: tc.callId,
+    }))
+    return (
+      <Chunk>
+        <AssistantMessage toolCalls={assistantToolCalls}>{round.response}</AssistantMessage>
+        {round.toolCalls.map((toolCall) => (
+          <ToolResultElement
+            toolCall={toolCall}
+            toolInvocationToken={this.props.toolInvocationToken}
+            toolCallResult={this.props.toolCallResults[toolCall.callId]}
+          />
+        ))}
+      </Chunk>
+    )
+  }
+}
+
+interface ToolResultElementProps extends BasePromptElementProps {
+  toolCall: LanguageModelToolCallPart
+  toolInvocationToken: ChatParticipantToolToken | undefined
+  toolCallResult: LanguageModelToolResult | undefined
+}
+
+/**
+ * One tool call result, which either comes from the cache or from invoking the tool.
+ */
+class ToolResultElement extends PromptElement<ToolResultElementProps, void> {
+  async render(state: void, sizing: PromptSizing): Promise<PromptPiece | undefined> {
+    const tool = lm.tools.find((t) => t.name === this.props.toolCall.name)
+    if (!tool) {
+      console.error(`Tool not found: ${this.props.toolCall.name}`)
+      return <ToolMessage toolCallId={this.props.toolCall.callId}>Tool not found</ToolMessage>
+    }
+
+    const tokenizationOptions: LanguageModelToolTokenizationOptions = {
+      tokenBudget: sizing.tokenBudget,
+      countTokens: async (content: string) => sizing.countTokens(content),
+    }
+
+    //console.log(`FBAI ToolResult ${this.props.toolCallResult ? 'using from cache' : 'invoking tool'}`)
+
+    const toolResult =
+      this.props.toolCallResult ??
+      (await lm.invokeTool(
+        this.props.toolCall.name,
+        { input: this.props.toolCall.input, toolInvocationToken: this.props.toolInvocationToken, tokenizationOptions },
+        dummyCancellationToken,
+      ))
+    //console.log(`FBAI ToolResult toolResult:`, toolResult)
+
+    return (
+      <ToolMessage toolCallId={this.props.toolCall.callId}>
+        <meta value={new ToolResultMetadata(this.props.toolCall.callId, toolResult)}></meta>
+        <ToolResult data={toolResult} />
+      </ToolMessage>
+    )
+  }
+}
+
+export class ToolResultMetadata extends PromptMetadata {
+  constructor(
+    public toolCallId: string,
+    public result: LanguageModelToolResult,
+  ) {
+    //console.log('FBAI ToolResultMetadata created with toolCallId:', toolCallId, result)
+    super()
+  }
+}

--- a/src/extension/fbAiTools.ts
+++ b/src/extension/fbAiTools.ts
@@ -1,0 +1,367 @@
+import * as vscode from 'vscode'
+import * as JSON5 from 'json5'
+import { FBAIProvider, SequencesResult } from './fbAIProvider'
+import { DocData } from './fbaEditor'
+import { DltFilter, escapeForMD, FbSequenceResult, lastEventForOccurrence, seqResultToMdAst } from 'dlt-logs-utils/sequence'
+import { toMarkdown } from 'mdast-util-to-markdown'
+import { gfmTableToMarkdown } from 'mdast-util-gfm-table'
+import { RQ, rqUriDecode, rqUriEncode } from 'dlt-logs-utils/restQuery'
+import { hashForFishbone } from './fbAiFishboneContext'
+import { FBBadge } from './fbaFormat'
+
+interface IRootcauseDetailsParameters {
+  fbUid: string
+}
+
+// #region RootcauseDetails
+export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcauseDetailsParameters> {
+  constructor(private provider: FBAIProvider) {}
+
+  getFilterFragsFor(rqString: string) {
+    try {
+      const rq = rqUriDecode(rqString)
+      const fragsToRet = []
+      const mapFrag = (f: any) => {
+        const newF = {
+          ...f,
+          tmpFb: undefined,
+        }
+        return newF
+      }
+      for (const cmd of rq.commands) {
+        switch (cmd.cmd) {
+          case 'query':
+          case 'add':
+            {
+              // console.log(`FBAI getFilterFragsFor got command:${cmd.cmd} with param:`, cmd.param)
+              const filterFrags = JSON5.parse(cmd.param)
+              if (filterFrags !== undefined) {
+                if (Array.isArray(filterFrags) && filterFrags.length > 0) {
+                  fragsToRet.push(...filterFrags.map(mapFrag))
+                } else if (typeof filterFrags === 'object' && filterFrags !== null) {
+                  fragsToRet.push(mapFrag(filterFrags))
+                } else {
+                  console.warn(`FBAI getFilterFragsFor got invalid filter fragment: ${JSON.stringify(filterFrags)}`)
+                }
+              }
+            }
+            break
+          case 'sequences':
+          case 'report': // TODO from here we could use the filter frags as well! (or special support for conversionFn?)
+          case 'delete':
+          case 'patch':
+          case 'enableAll':
+          case 'disableAll':
+            break
+          default:
+            console.warn(`FBAI getFilterFragsFor ignored command:${cmd.cmd}`)
+        }
+      }
+      return fragsToRet
+    } catch (e) {
+      console.warn(`FBAI getFilterFragsFor got error:${e}`)
+      return undefined
+    }
+  }
+
+  async processBadge(docData: DocData, badge: FBBadge) {
+    try {
+      const r = this.provider.evaluateRestQuery(docData, badge)
+      if (r !== undefined) {
+        const res = await r
+        if (res !== undefined) {
+          console.log('FBAI processBadge got result:', res)
+          if (res instanceof SequencesResult) {
+            if (res.result.length === 0) {
+              return undefined
+            }
+            let toRet = ''
+            for (const seq of res.result) {
+              if (typeof seq === 'string') {
+                toRet += `${seq}\n`
+              } else {
+                // a proper seq occurrence
+                if (seq.occurrences.length > 0) {
+                  // add a summary for each occurrence and details for the non ok ones:
+                  toRet += '```'
+                  toRet += `For sequence '${seq.sequence.name}' ${seq.occurrences.length} ${
+                    seq.occurrences.length > 1 ? 'occurrence has' : 'occurrences have'
+                  } been found:\n\n`
+                  // TODO compare number of tokens for html table and accurracy on understanding
+                  // (or yaml table or csv/tab separated values)
+                  // output as markdown table with occ #, occ status, context and kpis
+                  toRet += '| # | result | time | context | KPIs |\n'
+                  toRet += '|-|-|-|-|-|\n'
+                  for (const occ of seq.occurrences) {
+                    const status = occ.result
+                    const startEvent = occ.startEvent
+                    const lastEvent = lastEventForOccurrence(occ)
+                    const timeStr =
+                      lastEvent.timeInMs && startEvent.timeInMs && lastEvent.timeInMs !== startEvent.timeInMs
+                        ? `${new Date(startEvent.timeInMs).toLocaleString('de-DE')} - ${new Date(lastEvent.timeInMs).toLocaleString(
+                            'de-DE',
+                          )}`
+                        : startEvent.timeInMs
+                          ? new Date(startEvent.timeInMs).toLocaleString('de-DE')
+                          : startEvent.timeStamp
+                    const context = escapeForMD(occ.context.map(([key, value]) => `${key}: ${value}`).join(', '))
+                    const kpis = escapeForMD(occ.kpis.map((k) => `${k.name}: ${k.values.join(', ')}`).join(', '))
+                    toRet += `| ${occ.instance} | ${status} | ${timeStr} | ${context} | ${kpis} |\n`
+                  }
+                  // add details for each non-ok ones:
+                  const failedOccs = seq.occurrences.filter((occ) => occ.result !== 'ok')
+                  if (failedOccs.length > 0) {
+                    toRet += `\n\nDetails for the non-ok occurrences:\n`
+                    const failedSeqRes: FbSequenceResult = {
+                      ...seq,
+                      occurrences: failedOccs,
+                      logs: [], // we dont want logs from seq. processing here
+                    }
+                    const resAsMd = seqResultToMdAst(failedSeqRes)
+                    const resAsMarkdown = toMarkdown(
+                      { type: 'root', children: resAsMd },
+                      { extensions: [gfmTableToMarkdown({ tablePipeAlign: false })] },
+                    )
+                    toRet += resAsMarkdown
+                    toRet += '\n\n'
+                  }
+                  toRet += '```'
+                } else {
+                  toRet += `For sequence '${seq.sequence.name}' no occurrences have been found.`
+                }
+              }
+            }
+            return toRet
+          } else {
+            switch (typeof res) {
+              case 'bigint':
+              case 'number':
+              case 'boolean':
+              case 'string':
+                return res.toString()
+              case 'object':
+                return JSON.stringify(res)
+              default:
+                return undefined
+            }
+          }
+        } else {
+          console.warn(`FBAI processBadge got no result for badge: ${JSON.stringify(badge)}`)
+          return undefined
+        }
+      }
+    } catch (e) {
+      console.warn(`FBAI processBadge got error:${e}`)
+      return undefined
+    }
+  }
+
+  async invoke(options: vscode.LanguageModelToolInvocationOptions<IRootcauseDetailsParameters>, _token: vscode.CancellationToken) {
+    const params = options.input
+    console.log('FBAIProvider RCDT invoked with params:', params)
+    if (typeof params.fbUid === 'string') {
+      // we expect a fbUid like 'fbaHash_rcUid' or 'rcUid'
+      const splitted = params.fbUid.split('_') // '_' should never be part of a fbUid (short-unique-id uses alphanum only)
+      const fbaHash = splitted.length > 1 ? Number(params.fbUid.split('_')[0]) : undefined
+      const rcUid = splitted.length > 1 ? params.fbUid.split('_')[1] : params.fbUid
+      // if fbaHash is defined we check if it is the same as the one in the fishbone
+      // if fbaHash is not defined we use the first matching one
+      // this is to handle the case where the user has multiple fishbones with the same root cause (e.g. copied once...)
+
+      const fbs = this.provider.getFishbones() // TODO make it a parameter...
+      let rc = undefined
+      let docData = undefined
+
+      for (const fb of fbs) {
+        if (fbaHash !== undefined && fb.lastPostedObj !== undefined && hashForFishbone(fb.lastPostedObj) !== fbaHash) {
+          continue
+        }
+        rc = this.provider.getRootCause(fb.lastPostedObj!, rcUid)
+        if (rc !== undefined) {
+          docData = fb
+          break
+        }
+      }
+      if (rc !== undefined) {
+        const textOfStringOrMD = (value: string | { textValue: string }) => {
+          return typeof value === 'string' ? value : value.textValue
+        }
+
+        console.log('FBAIProvider RCDT found rc:', rc)
+
+        // check for rc.props.badge and rc.props.badge2
+        // and rc.props.filter
+        const upperBadge = docData && rc.props?.badge ? await this.processBadge(docData, rc.props.badge) : undefined
+        const lowerBadge = docData && rc.props?.badge2 ? await this.processBadge(docData, rc.props.badge2) : undefined
+        const filterFrags =
+          rc.props?.filter?.source && typeof rc.props.filter.source === 'string'
+            ? this.getFilterFragsFor(rc.props.filter.source)
+            : undefined
+        console.log(`FBAI RCDT upperBadge=${upperBadge}`)
+        console.log(`FBAI RCDT lowerBadge=${lowerBadge}`)
+        // console.log(`FBAI RCDT filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
+        if (filterFrags !== undefined && docData !== undefined) {
+          // need to substitute attributes here as the root cause results are specific for a set of attributes
+          this.provider.substFilterAttributes(docData, filterFrags)
+          // console.log(`FBAI RCDT subst filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
+        }
+
+        return new vscode.LanguageModelToolResult(
+          [
+            new vscode.LanguageModelTextPart(`The root cause with fbUid:'${options.input.fbUid}':`),
+            new vscode.LanguageModelTextPart(`name:'${rc.title || rc.props?.label}'`),
+            rc.props?.backgroundDescription !== undefined
+              ? new vscode.LanguageModelTextPart(`background:'${textOfStringOrMD(rc.props.backgroundDescription)}'`)
+              : undefined,
+            rc.props?.instructions !== undefined
+              ? new vscode.LanguageModelTextPart(`instructions:'${textOfStringOrMD(rc.props.instructions)}'`)
+              : undefined,
+            upperBadge !== undefined ? new vscode.LanguageModelTextPart(`upper badge:'${upperBadge}'`) : undefined,
+            lowerBadge !== undefined ? new vscode.LanguageModelTextPart(`lower badge:'${lowerBadge}'`) : undefined,
+            filterFrags !== undefined && filterFrags.length > 0
+              ? new vscode.LanguageModelTextPart(`filters from 'apply filter'` + '```json\n' + JSON.stringify(filterFrags) + '```\n')
+              : undefined,
+          ].filter((part) => part !== undefined),
+        )
+      } else {
+        console.warn(`FBAIProvider RCDT found no rc with that fbUid:'${options.input.fbUid}'`)
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart('Invalid parameter. fbUid not for a known root cause.'),
+        ])
+      }
+    } else {
+      return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Invalid parameter. fbUid not a string')])
+    }
+  }
+
+  async prepareInvocation(
+    options: vscode.LanguageModelToolInvocationPrepareOptions<IRootcauseDetailsParameters>,
+    _token: vscode.CancellationToken,
+  ) {
+    const confirmationMessages = {
+      title: 'Providing details for a fishbone root cause',
+      message: new vscode.MarkdownString(`Provide details for fishbone root cause (${options.input.fbUid})?`),
+    }
+
+    return {
+      invocationMessage: `Providing details for fishbone root cause (${options.input.fbUid})`,
+      // not needed here, tool usage is non costly and shares no data. confirmationMessages,
+    }
+  }
+}
+
+// #region QueryLogs
+
+// Decision: no attributes support here. Needs to be substituted upfront.
+// add fbUid from rootcause to identify the fishbone.attributes to use?
+interface IQueryLogsParameters {
+  filters: {
+    // all filter frags are supported not just apid, ctid
+    type: number
+    apid?: string
+    ctid?: string
+  }[]
+}
+
+export class QueryLogsTool implements vscode.LanguageModelTool<IQueryLogsParameters> {
+  constructor(private provider: FBAIProvider) {}
+
+  async processFilters(filters: DltFilter[]) {
+    try {
+      const filterFrags = filters.map((f) => f.asConfiguration())
+      if (filterFrags.length > 0) {
+        // we want lifecycles as well:
+        filterFrags[0].addLifecycles = true
+        // if we ever want to get more than 1000 msgs:
+        // filterFrags[0].maxNrMsgs = 1000
+      }
+      const rq: RQ = {
+        path: 'ext:mbehr1.dlt-logs/get/docs/0/filters',
+        commands: [
+          {
+            cmd: 'query',
+            param: JSON.stringify(filterFrags),
+          },
+        ],
+      }
+      const r = await this.provider.performRestQueryUri(rqUriEncode(rq)).then(
+        (resJson) => {
+          if (resJson.data && Array.isArray(resJson.data)) {
+            const lcsMap: Map<number, any> = new Map(
+              resJson.data.filter((d: any) => d.type === 'lifecycles').map((l: any) => [l.id, l.attributes]),
+            )
+
+            // return the calculated time for the messages
+            // as lc start time + monotonic time stamp
+            const calcTime = (lcId: number, timeStamp_dms: number) => {
+              const lc = lcsMap.get(lcId)
+              if (lc !== undefined) {
+                let startTime_ms = Date.parse(lc.startTimeUtc)
+                let calcTime = startTime_ms + timeStamp_dms / 10
+                return new Date(calcTime) // or as de-de locale string? TODO think about time zone support.
+              } else {
+                return undefined
+              }
+            }
+
+            const msgs: any[] = resJson.data
+              .filter((d: any) => d.type === 'msg')
+              .map((d: any) => {
+                return {
+                  idx: d.id,
+                  calcTime: calcTime(d.attributes.lifecycle, d.attributes.timeStamp),
+                  ...d.attributes,
+                  timeStamp: d.attributes.timeStamp / 10000, // convert to secs
+                } // TODO add recordedTimeMs (from dlt-logs)
+              })
+            // TODO add info on the columns here (or at the tools definition?)
+            return `query for filters returned ${msgs.length} logs:\n` + '```\n' + JSON.stringify(msgs) + '\n```\n'
+          } else {
+            return `query for filters returned no data: '${JSON.stringify(resJson)}'`
+          }
+        },
+        (rejectReason) => {
+          return `query for filters failed with: '${rejectReason}'`
+        },
+      )
+      return r
+    } catch (e) {
+      return `query for filters failed with exception: '${e}'`
+    }
+  }
+  async invoke(options: vscode.LanguageModelToolInvocationOptions<IQueryLogsParameters>, _token: vscode.CancellationToken) {
+    const params = options.input
+    console.log('FBAIProvider QLT invoked with params:', params)
+
+    if (Array.isArray(params.filters) && params.filters.length > 0) {
+      try {
+        const filters = params.filters.map((frag) => new DltFilter(frag))
+        const res = await this.processFilters(filters)
+        console.log(`FBAIProvider QLT got res:${JSON.stringify(res, undefined, 2)}`)
+        if (typeof res === 'string') {
+          return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(res)])
+        }
+        return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`No logs are matching the ${params.filters} filters.`)])
+      } catch (e) {
+        return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`Invalid parameter. Parsing filters got error:${e}`)])
+      }
+    } else {
+      return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Invalid parameter. filters not an array')])
+    }
+  }
+
+  async prepareInvocation(
+    options: vscode.LanguageModelToolInvocationPrepareOptions<IQueryLogsParameters>,
+    _token: vscode.CancellationToken,
+  ) {
+    const confirmationMessages = {
+      title: 'Provide logs matching a set of filters',
+      message: new vscode.MarkdownString(`Provide logs matching ${options.input.filters.length} filters?`),
+    }
+
+    return {
+      invocationMessage: `Provide logs matching ${options.input.filters.length} filters?`,
+      // not needed here, tool usage is non costly and shares no data. confirmationMessages,
+    }
+  }
+}

--- a/src/extension/fbaEditor.ts
+++ b/src/extension/fbaEditor.ts
@@ -533,7 +533,11 @@ export class FBAEditorProvider implements vscode.CustomTextEditorProvider, vscod
         removed.forEach((item) => {
           // we change the lastPostedObj to an empty obj to indicate that it's not existing now
           if (item.docData) {
-            item.docData.lastPostedObj = {} as Fishbone
+            item.docData.lastPostedObj = {
+              title: '',
+              attributes: [],
+              fishbone: [],
+            }
           }
           this._fsProvider.onFbaDocChanges(item)
         })

--- a/src/extension/fbaFSProvider.ts
+++ b/src/extension/fbaFSProvider.ts
@@ -118,7 +118,7 @@ export class FBAFSProvider implements vscode.FileSystemProvider {
       const getElemFromDoc = (uri: vscode.Uri, doc: FishboneTreeItem): OpenedFileData | undefined => {
         const lastFBA = doc.docData!.lastPostedObj
         // now search for the fbUid
-        const elem = FBAFSProvider.getElemFromFBA(lastFBA, uriParameters)
+        const elem = lastFBA !== undefined ? FBAFSProvider.getElemFromFBA(lastFBA, uriParameters) : undefined
         console.log(`FBAFSProvider.getDataForUri found elem`, elem)
         if (elem) {
           const entry = {

--- a/src/extension/fbaFormat.ts
+++ b/src/extension/fbaFormat.ts
@@ -39,6 +39,7 @@ export interface FBAttribute {
 }
 export interface FBEffect {
   fbUid: string
+  name: string
   categories: FBCategory[]
 }
 
@@ -64,6 +65,7 @@ export interface FBRootCause {
 
 export interface FBCategory {
   fbUid: string
+  name: string
   rootCauses: FBRootCause[]
 }
 

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -33,7 +33,8 @@
     "build": "react-scripts build",
     "postbuild": "mkdir -p ../../out && rimraf ../../out/webview && mv build ../../out/webview && rimraf ../../docs/fishbone/static/online && cp -r ../../out/webview/ ../../docs/fishbone/static/online",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "watch": "BROWSER=none react-scripts start"
   },
   "eslintConfig": {
     "extends": [

--- a/src/webview/src/App.js
+++ b/src/webview/src/App.js
@@ -5,7 +5,7 @@
  * - add/edit attributes via UI
  * - add/edit filter via UI
  * - add/edit badges via UI
- * - add lifecycle selection
+ * [x] add lifecycle selection
  * - rethink "react" class support (function as string parsed to js?)
  *
  * - use webpack (or something else) for proper react "app" bundling/generation incl. debugging support

--- a/src/webview/yarn.lock
+++ b/src/webview/yarn.lock
@@ -3539,9 +3539,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001407:
-  version "1.0.30001525"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
-  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
+  version "1.0.30001714"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz"
+  integrity sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,15 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    // tsx support
+    "jsx": "react",
+    "jsxFactory": "vscpp",
+    "jsxFragmentFactory": "vscppf"
   },
   "exclude": [
     "node_modules",

--- a/tsconfig_test.json
+++ b/tsconfig_test.json
@@ -7,7 +7,10 @@
     "lib": ["es2021"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true
+    "strict": true,
+    "jsx": "react",
+    "jsxFactory": "vscpp",
+    "jsxFragmentFactory": "vscppf"
   },
   "exclude": ["node_modules", ".vscode-test", "src/webview", "src/extension"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,10 +1223,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/vscode@^1.80.0":
-  version "1.82.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.82.0.tgz#89b0b21179dcf5e8cee1664a9a05c5f6c60d38d0"
-  integrity sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==
+"@types/vscode@^1.99.1":
+  version "1.99.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.99.1.tgz#bde6e2d9ccbe0493fded98ad639bf2671b8ec9ee"
+  integrity sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ==
 
 "@typescript-eslint/eslint-plugin@^6.7.3":
   version "6.7.3"
@@ -1326,6 +1326,11 @@
     "@microsoft/1ds-core-js" "^4.3.4"
     "@microsoft/1ds-post-js" "^4.3.4"
     "@microsoft/applicationinsights-web-basic" "^3.3.4"
+
+"@vscode/prompt-tsx@^0.3.0-alpha.24":
+  version "0.3.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/@vscode/prompt-tsx/-/prompt-tsx-0.3.0-alpha.24.tgz#ae3960a29dfffc291dee0a7cd6882bed169bde6b"
+  integrity sha512-WUz6rPLcN6F64WxxwTiLzHOuhUcdLKBWMckppn43DBC1Ba67Lvd9RV+2LOxj938YzvEVOKGoAY/qgRtXd77I7Q==
 
 "@vscode/vsce-sign-alpine-arm64@2.0.2":
   version "2.0.2"
@@ -6450,6 +6455,11 @@ safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+safe-stable-stringify@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"


### PR DESCRIPTION
- Add "fishbone.ai" / @fai to copilot chat window.
- Has info about:
  - the current log loaded,
  - the current fishbones opened
  - can read root cause details like background, instructions
  - can evaluate upper & lower badge values
  - can perform log queries based on the "apply filter" button.

It's important to fill out the fields:
- effect (effect name should reflect a problem like "flash problem")
- category names
- root cause name, background and instructions.
- use reasonable values for upper (warnings alike) and lower badge (informations).

Attributes (e.g. filter for ecu or lifecycles) are applied! Using them eases the AI to understand/restrict results/provide better results.

Needs github copilot setup and providing a model with tools support (e.g. GPT-4o or o1).