### PR TITLE
fix(fAi): provide proper inputSchema for tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://mbehr1.github.io/fishbone/",
   "engines": {
-    "vscode": "^1.99.1"
+    "vscode": "^1.102.0"
   },
   "categories": [
     "Visualization",
@@ -98,7 +98,10 @@
               "type": "string",
               "description": "The uid of the root cause to provide details for. It needs to be exactly the fbUid without any additional characters pre- or appended."
             }
-          }
+          },
+          "required": [
+            "fbUid"
+          ]
         }
       },
       {
@@ -117,12 +120,19 @@
           "properties": {
             "filters": {
               "type": "array",
+              "minItems": 1,
+              "description": "List of filters to apply. If no positive filter is provided all logs are shown that are not filtered out by negative filters. If any positive filter is provided only logs passing: any (or) of the positive filters and are not filtered out by any of the negative filters.",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "type": {
                     "type": "number",
                     "description": "The type of the filter (0 = pos, 1 = negative)."
+                  },
+                  "ecu": {
+                    "type": "string",
+                    "description": "Optional ecu to filter for."
                   },
                   "apid": {
                     "type": "string",
@@ -135,6 +145,22 @@
                   "payloadRegex": {
                     "type": "string",
                     "description": "Optional regular expression to filter the payload of the log for."
+                  },
+                  "ignoreCasePayload": {
+                    "type": "boolean",
+                    "description": "Optional flag to ignore case for the payload regex. If not set any payload search is case sensitive."
+                  },
+                  "logLevelMin": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 6,
+                    "description": "Optional minimum log level to filter for. The following log-levels are defined: FATAL=1, ERROR=2, WARNING=3, INFO=4, DEBUG=5, VERBOSE=6."
+                  },
+                  "logLevelMax": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 6,
+                    "description": "Optional maximum log level to filter for. E.g. to add all messages with warnings, error or fatal messages use a positive filter with logLevelMax = 3."
                   }
                 },
                 "required": [
@@ -142,7 +168,10 @@
                 ]
               }
             }
-          }
+          },
+          "required": [
+            "filters"
+          ]
         }
       }
     ],
@@ -227,7 +256,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^22.16.5",
     "@types/request": "^2.48.12",
-    "@types/vscode": "^1.99.1",
+    "@types/vscode": "^1.102.0",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "esbuild": "^0.25.8",
@@ -261,7 +290,8 @@
     "request": "^2.88.2",
     "safe-stable-stringify": "^2.5.0",
     "short-unique-id": "4.4.4",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "zod": "4.0.17"
   },
   "commitlint": {
     "extends": [

--- a/src/extension/fbAiFishboneContext.tsx
+++ b/src/extension/fbAiFishboneContext.tsx
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode'
 import { BasePromptElementProps, PromptElement, PromptPiece, PromptSizing, UserMessage } from '@vscode/prompt-tsx'
-import { stringify } from 'safe-stable-stringify'
+
 import { Fishbone } from './fbaFormat'
+import { safeStableStringify } from './util'
 
 export interface IFBsToInclude {
   uri: vscode.Uri | undefined
@@ -64,21 +65,6 @@ export class FishboneContext extends PromptElement<{ fbs: IFBsToInclude[]; fbaHa
   }
 }
 
-// #region hash / safe-stable-stringify
-
-// TODO put into utils... (or even dlt-log-utils)
-/**
- * Safely converts an object to a string representation, including support for BigInts.
- *
- * @param obj - The object to stringify.
- * @returns The string representation of the object.
- */
-function safeStableStringify(obj: any): string {
-  // safe-stable-stringify handles bigints but by representing as number strings that
-  // later on cannot be parsed and where the info that it was a bigint got lost
-  // so we convert bigints to strings with the number + 'n' here
-  return stringify(obj, (_, v) => (typeof v === 'bigint' ? v.toString() + 'n' : v)) || ''
-}
 
 // cyrb53 (c) 2018 bryc (github.com/bryc). License: Public domain. Attribution appreciated.
 // A fast and simple 64-bit (or 53-bit) string hash function with decent collision resistance.

--- a/src/extension/fbAiTools.ts
+++ b/src/extension/fbAiTools.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as JSON5 from 'json5'
+import { z } from 'zod'
 import { FBAIProvider, SequencesResult } from './fbAIProvider'
 import { DocData } from './fbaEditor'
 import { DltFilter, escapeForMD, FbSequenceResult, lastEventForOccurrence, seqResultToMdAst } from 'dlt-logs-utils/sequence'
@@ -8,14 +9,46 @@ import { gfmTableToMarkdown } from 'mdast-util-gfm-table'
 import { RQ, rqUriDecode, rqUriEncode } from 'dlt-logs-utils/restQuery'
 import { hashForFishbone } from './fbAiFishboneContext'
 import { FBBadge } from './fbaFormat'
+import { safeStableStringify } from './util'
 
-interface IRootcauseDetailsParameters {
-  fbUid: string
-}
+const RootCauseDetailsToolSchema = z.object({
+  fbUid: z
+    .string()
+    .describe(
+      'The uid of the root cause to provide details for. It needs to be exactly the fbUid without any additional characters pre- or appended.',
+    ),
+})
+type IRootcauseDetailsParameters = z.infer<typeof RootCauseDetailsToolSchema>
 
 // #region RootcauseDetails
 export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcauseDetailsParameters> {
-  constructor(private provider: FBAIProvider) {}
+  constructor(
+    private log: vscode.LogOutputChannel,
+    private provider: FBAIProvider,
+    toolInfo: vscode.LanguageModelToolInformation | undefined,
+  ) {
+    // verify the inputSchema
+    if (toolInfo?.inputSchema) {
+      // Perform schema validation here
+      try {
+        const expectedSchema = z.toJSONSchema(RootCauseDetailsToolSchema)
+        const expectedAsString = safeStableStringify(expectedSchema)
+        const currentAsString = safeStableStringify({
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          additionalProperties: false, // TODO weird, not accepted in package.json
+          ...toolInfo.inputSchema,
+        })
+        if (currentAsString !== expectedAsString) {
+          this.log.warn(
+            `Input schema does not match expected schema for RootcauseDetailsTool: expected:\n${expectedAsString}\nreceived:\n${currentAsString}`,
+          )
+        }
+      } catch (error) {
+        this.log.error('Invalid input schema for RootcauseDetailsTool:', error)
+        //throw new Error('Invalid input schema for RootcauseDetailsTool')
+      }
+    }
+  }
 
   getFilterFragsFor(rqString: string) {
     try {
@@ -33,7 +66,7 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
           case 'query':
           case 'add':
             {
-              // console.log(`FBAI getFilterFragsFor got command:${cmd.cmd} with param:`, cmd.param)
+              // this.log.info(`FBAI getFilterFragsFor got command:${cmd.cmd} with param:`, cmd.param)
               const filterFrags = JSON5.parse(cmd.param)
               if (filterFrags !== undefined) {
                 if (Array.isArray(filterFrags) && filterFrags.length > 0) {
@@ -41,7 +74,7 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
                 } else if (typeof filterFrags === 'object' && filterFrags !== null) {
                   fragsToRet.push(mapFrag(filterFrags))
                 } else {
-                  console.warn(`FBAI getFilterFragsFor got invalid filter fragment: ${JSON.stringify(filterFrags)}`)
+                  this.log.warn(`FBAI getFilterFragsFor got invalid filter fragment: ${JSON.stringify(filterFrags)}`)
                 }
               }
             }
@@ -54,23 +87,24 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
           case 'disableAll':
             break
           default:
-            console.warn(`FBAI getFilterFragsFor ignored command:${cmd.cmd}`)
+            this.log.warn(`FBAI getFilterFragsFor ignored command:${cmd.cmd}`)
         }
       }
       return fragsToRet
     } catch (e) {
-      console.warn(`FBAI getFilterFragsFor got error:${e}`)
+      this.log.error(`FBAI getFilterFragsFor got error:${e}`)
       return undefined
     }
   }
 
   async processBadge(docData: DocData, badge: FBBadge) {
+    const log = this.log
     try {
       const r = this.provider.evaluateRestQuery(docData, badge)
       if (r !== undefined) {
         const res = await r
         if (res !== undefined) {
-          console.log('FBAI processBadge got result:', res)
+          log.info('FBAI processBadge got result:', res)
           if (res instanceof SequencesResult) {
             if (res.result.length === 0) {
               return undefined
@@ -146,19 +180,20 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
             }
           }
         } else {
-          console.warn(`FBAI processBadge got no result for badge: ${JSON.stringify(badge)}`)
+          log.warn(`FBAI processBadge got no result for badge: ${JSON.stringify(badge)}`)
           return undefined
         }
       }
     } catch (e) {
-      console.warn(`FBAI processBadge got error:${e}`)
+      log.warn(`FBAI processBadge got error:${e}`)
       return undefined
     }
   }
 
   async invoke(options: vscode.LanguageModelToolInvocationOptions<IRootcauseDetailsParameters>, _token: vscode.CancellationToken) {
+    const log = this.log
     const params = options.input
-    console.log('FBAIProvider RCDT invoked with params:', params)
+    log.info('FBAIProvider RCDT invoked with params:', params)
     if (typeof params.fbUid === 'string') {
       // we expect a fbUid like 'fbaHash_rcUid' or 'rcUid'
       const splitted = params.fbUid.split('_') // '_' should never be part of a fbUid (short-unique-id uses alphanum only)
@@ -187,7 +222,7 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
           return typeof value === 'string' ? value : value.textValue
         }
 
-        console.log('FBAIProvider RCDT found rc:', rc)
+        log.info('FBAIProvider RCDT found rc:', rc)
 
         // check for rc.props.badge and rc.props.badge2
         // and rc.props.filter
@@ -197,13 +232,13 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
           rc.props?.filter?.source && typeof rc.props.filter.source === 'string'
             ? this.getFilterFragsFor(rc.props.filter.source)
             : undefined
-        console.log(`FBAI RCDT upperBadge=${upperBadge}`)
-        console.log(`FBAI RCDT lowerBadge=${lowerBadge}`)
-        // console.log(`FBAI RCDT filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
+        log.info(`FBAI RCDT upperBadge=${upperBadge}`)
+        log.info(`FBAI RCDT lowerBadge=${lowerBadge}`)
+        // log.info(`FBAI RCDT filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
         if (filterFrags !== undefined && docData !== undefined) {
           // need to substitute attributes here as the root cause results are specific for a set of attributes
           this.provider.substFilterAttributes(docData, filterFrags)
-          // console.log(`FBAI RCDT subst filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
+          // log.info(`FBAI RCDT subst filterFrags=${JSON.stringify(filterFrags, undefined, 2)}`)
         }
 
         return new vscode.LanguageModelToolResult(
@@ -224,7 +259,7 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
           ].filter((part) => part !== undefined),
         )
       } else {
-        console.warn(`FBAIProvider RCDT found no rc with that fbUid:'${options.input.fbUid}'`)
+        log.warn(`FBAIProvider RCDT found no rc with that fbUid:'${options.input.fbUid}'`)
         return new vscode.LanguageModelToolResult([
           new vscode.LanguageModelTextPart('Invalid parameter. fbUid not for a known root cause.'),
         ])
@@ -252,19 +287,75 @@ export class RootcauseDetailsTool implements vscode.LanguageModelTool<IRootcause
 
 // #region QueryLogs
 
+const QueryLogsParametersSchema = z.object({
+  filters: z
+    .array(
+      z.object({
+        type: z.number().describe('The type of the filter (0 = pos, 1 = negative).'),
+        ecu: z.string().optional().describe('Optional ecu to filter for.'),
+        apid: z.string().optional().describe('Optional apid (application id) to filter for.'),
+        ctid: z.string().optional().describe('Optional ctid (context id) to filter for.'),
+        payloadRegex: z.string().optional().describe('Optional regular expression to filter the payload of the log for.'),
+        ignoreCasePayload: z
+          .boolean()
+          .optional()
+          .describe('Optional flag to ignore case for the payload regex. If not set any payload search is case sensitive.'),
+        logLevelMin: z
+          .number()
+          .min(1)
+          .max(6)
+          .optional()
+          .describe(
+            'Optional minimum log level to filter for. The following log-levels are defined: FATAL=1, ERROR=2, WARNING=3, INFO=4, DEBUG=5, VERBOSE=6.',
+          ),
+        logLevelMax: z
+          .number()
+          .min(1)
+          .max(6)
+          .optional()
+          .describe(
+            'Optional maximum log level to filter for. E.g. to add all messages with warnings, error or fatal messages use a positive filter with logLevelMax = 3.',
+          ),
+      }),
+    )
+    .min(1)
+    .describe(
+      'List of filters to apply. If no positive filter is provided all logs are shown that are not filtered out by negative filters. If any positive filter is provided only logs passing: any (or) of the positive filters and are not filtered out by any of the negative filters.',
+    ),
+})
+type IQueryLogsParameters = z.infer<typeof QueryLogsParametersSchema>
+
 // Decision: no attributes support here. Needs to be substituted upfront.
 // add fbUid from rootcause to identify the fishbone.attributes to use?
-interface IQueryLogsParameters {
-  filters: {
-    // all filter frags are supported not just apid, ctid
-    type: number
-    apid?: string
-    ctid?: string
-  }[]
-}
 
 export class QueryLogsTool implements vscode.LanguageModelTool<IQueryLogsParameters> {
-  constructor(private provider: FBAIProvider) {}
+  constructor(
+    private log: vscode.LogOutputChannel,
+    private provider: FBAIProvider,
+    toolInfo: vscode.LanguageModelToolInformation | undefined,
+  ) {
+    // verify the inputSchema
+    if (toolInfo?.inputSchema) {
+      // Perform schema validation here
+      try {
+        const expectedSchema = z.toJSONSchema(QueryLogsParametersSchema)
+        const expectedAsString = safeStableStringify(expectedSchema)
+        const currentAsString = safeStableStringify({
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          additionalProperties: false, // TODO weird, not accepted in package.json
+          ...toolInfo.inputSchema,
+        })
+        if (currentAsString !== expectedAsString) {
+          this.log.warn(
+            `Input schema does not match expected schema for QueryLogsTool: expected:\n${expectedAsString}\nreceived:\n${currentAsString}`,
+          )
+        }
+      } catch (error) {
+        this.log.error('Invalid input schema for QueryLogsTool:', error)
+        //throw new Error('Invalid input schema for QueryLogsTool')
+      }
+    }
+  }
 
   async processFilters(filters: DltFilter[]) {
     try {
@@ -330,14 +421,15 @@ export class QueryLogsTool implements vscode.LanguageModelTool<IQueryLogsParamet
     }
   }
   async invoke(options: vscode.LanguageModelToolInvocationOptions<IQueryLogsParameters>, _token: vscode.CancellationToken) {
+    const log = this.log
     const params = options.input
-    console.log('FBAIProvider QLT invoked with params:', params)
+    log.info('FBAIProvider QLT invoked with params:', params)
 
     if (Array.isArray(params.filters) && params.filters.length > 0) {
       try {
         const filters = params.filters.map((frag) => new DltFilter(frag))
         const res = await this.processFilters(filters)
-        console.log(`FBAIProvider QLT got res:${JSON.stringify(res, undefined, 2)}`)
+        log.info(`FBAIProvider QLT got res:${JSON.stringify(res, undefined, 2)}`)
         if (typeof res === 'string') {
           return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(res)])
         }

--- a/src/extension/util.ts
+++ b/src/extension/util.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import * as request from 'request'
 import { extensionId } from './constants'
+import { stringify } from 'safe-stable-stringify'
 import { URL } from 'url'
 import { Token, tokenize } from 'jju'
 
@@ -246,4 +247,19 @@ export const jsonTokenAtRange = (text: string, range: vscode.Range): Token | und
     console.warn(`jsonTokenAtRange failed with error:'${e}'`)
   }
   return convToken
+}
+
+// #region safe-stable-stringify
+
+/**
+ * Safely converts an object to a string representation, including support for BigInts.
+ *
+ * @param obj - The object to stringify.
+ * @returns The string representation of the object.
+ */
+export function safeStableStringify(obj: any): string {
+  // safe-stable-stringify handles bigints but by representing as number strings that
+  // later on cannot be parsed and where the info that it was a bigint got lost
+  // so we convert bigints to strings with the number + 'n' here
+  return stringify(obj, (_, v) => (typeof v === 'bigint' ? v.toString() + 'n' : v)) || ''
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,10 +1449,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/vscode@^1.99.1":
-  version "1.99.1"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.99.1.tgz#bde6e2d9ccbe0493fded98ad639bf2671b8ec9ee"
-  integrity sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ==
+"@types/vscode@^1.102.0":
+  version "1.102.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.102.0.tgz#186dd6d4755807754a18ca869384c93b821039f2"
+  integrity sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==
 
 "@typescript-eslint/eslint-plugin@^6.7.3":
   version "6.7.3"
@@ -8499,6 +8499,11 @@ yoctocolors@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.1.tgz#e0167474e9fbb9e8b3ecca738deaa61dd12e56fc"
   integrity sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==
+
+zod@4.0.17:
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.0.17.tgz#95931170715f73f7426c385c237b7477750d6c8d"
+  integrity sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
Added zod to verify and model internally the inputSchema. Sadly need to manually compare it and copy into the package.json. But this serves as a preparation for mcp server interfaces.

Corrected the input schema for queryTools with all (reasonable) properties for filters.