### PR TITLE
fix(fai): handle unknown prompts in fai.extends gracefully

### DIFF
--- a/src/extension/fbAIProvider.ts
+++ b/src/extension/fbAIProvider.ts
@@ -578,8 +578,16 @@ export class FBAIProvider implements vscode.Disposable {
               acc +
               (addedPrompts.has(cur) || processingPrompts.has(cur)
                 ? ''
-                : FBAIProvider.getFullPrompt(allOrigPrompts.find((p) => p.name === cur)!, addedPrompts, allOrigPrompts, processingPrompts)
-                    .content + '\n')
+                : FBAIProvider.getFullPrompt(
+                    allOrigPrompts.find((p) => p.name === cur) || {
+                      name: cur,
+                      content: `Error: Unknown prompt '${cur}' used for extends in '${prompt.name}'!`,
+                      data: {},
+                    },
+                    addedPrompts,
+                    allOrigPrompts,
+                    processingPrompts,
+                  ).content + '\n')
             )
           }, '') + (addedPrompts.has(prompt.name) ? '' : prompt.content),
         data: prompt.data,

--- a/src/test/suite/fbAIProvider.test.ts
+++ b/src/test/suite/fbAIProvider.test.ts
@@ -61,6 +61,12 @@ suite('FBAIProvider.getFullPrompt', () => {
     assert.strictEqual(countB , 1, `B appears more than once (${countB}) due to circular ref`)
     // we dont check order here as its kind of undefined
   })
+
+  test('handles non-existing extended prompt gracefully', () => {
+    const a = { name: 'a', content: 'A', data: { 'fai.extends': 'non-existing' } }
+    const resA = getFullPrompt(a, new Set(), [a])
+    assert.ok(resA.content.includes("Error: Unknown prompt 'non-existing'"), `res=${JSON.stringify(resA)}`)
+  })
 })
 
 suite('FBAIProvider.getPromptFiles', ()=>{

--- a/src/test/test_cmd1.prompt.md
+++ b/src/test/test_cmd1.prompt.md
@@ -2,7 +2,7 @@
 mode: 'agent'
 model: GPT-4o
 tools: []
-fai.extends: ['analyse']
+fai.extends: ['analyse', 'non-existing']
 description: 'Test command 1 for own prompts'
 ---
 Your goal is to analyse flash failures based on the provided logs and fishbone files. 


### PR DESCRIPTION
If prompt.md files contain fai.extends referencing an unknown prompt an error text is added to the prompt.
Previously it failed with reading name from undefined.